### PR TITLE
Add Jekyll-based personal website

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Project-001
+
+This repository contains a simple personal website built with Jekyll. The site is located in the `docs/` directory so it can be served with GitHub Pages.
+
+## Local development
+
+If you have Ruby installed, you can preview the site locally:
+
+```bash
+bundle install
+bundle exec jekyll serve --source docs
+```
+
+Then open `http://localhost:4000` in your browser.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+title: "My Personal Brand"
+description: "Personal site using Jekyll and the minima theme."
+theme: minima

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>{{ page.title }} - {{ site.title }}</title>
+  </head>
+  <body>
+    <header>
+      <h1>{{ site.title }}</h1>
+      <nav>
+        <a href="{{ '/' | relative_url }}">Home</a> |
+        <a href="{{ '/about' | relative_url }}">About</a>
+      </nav>
+    </header>
+    <main>
+      {{ content }}
+    </main>
+    <footer>
+      <p>&copy; {{ site.time | date: '%Y' }} {{ site.title }}</p>
+    </footer>
+  </body>
+</html>

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: About
+---
+
+# About
+
+Write something about yourself.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Home
+---
+
+# Welcome to My Personal Brand
+
+This is a simple website built with Jekyll for GitHub Pages.


### PR DESCRIPTION
## Summary
- create a `docs/` folder with a simple Jekyll site
- add a Gemfile for GitHub Pages
- document how to serve locally

## Testing
- `bundle exec jekyll build --source docs --destination build_output` *(fails: command not found)*
- `bundle install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685bac808fa883219b6a77fff8135be3