### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: Publish to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
+      - name: Install dependencies
+        run: |
+          bundle install --jobs 4 --retry 3
+
+      - name: Build site
+        run: bundle exec jekyll build --source docs --destination site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ bundle exec jekyll serve --source docs
 ```
 
 Then open `http://localhost:4000` in your browser.
+
+## Continuous Deployment
+
+Every push to the `main` branch triggers a GitHub Actions workflow that builds the site from the `docs/` directory and deploys it to GitHub Pages.


### PR DESCRIPTION
## Summary
- create GitHub Actions workflow to build and deploy the site from `docs/` to GitHub Pages
- document continuous deployment in README

## Testing
- `bundle exec jekyll build --source docs --destination _site` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb51666348321bfebacae9230b29e