### PR TITLE
Update artifact action version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         run: bundle exec jekyll build --source docs --destination site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: ./site
 


### PR DESCRIPTION
## Summary
- update the upload action to a version that supports `actions/upload-artifact@v4`

## Testing
- `bundle exec jekyll build --source docs --destination site` *(fails: bundler command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb5fc18d0832180d5ad9b0c7a01c3